### PR TITLE
Add linux and nmap free tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Pull requests are welcome with the condition that the resource should be free! P
 * [Principles of security](<https://tryhackme.com/room/principlesofsecurity>) - Principles of security.
 * [Red Team Engagements](<https://tryhackme.com/room/redteamengagements>) - Intro to red team engagements.
 * [Hip Flask](https://tryhackme.com/room/hipflask) - An in-depth walkthrough covering pentest methodology against a vulnerable server.
+* [Practice Linux Commands](https://labex.io/courses/linux-basic-commands-practice-online) - A free course with 41 hands-on labs to practice and master the most commonly used Linux commands.
 
 <!-- markdownlint-disable MD036 -->
 **Introductory CTFs to get your feet wet**<!-- markdownlint-enable MD036 -->
@@ -92,6 +93,7 @@ Pull requests are welcome with the condition that the resource should be free! P
 * [Linux Privesc](<https://tryhackme.com/room/linuxprivesc>) - Practice your Linux Privilege Escalation skills on an intentionally misconfigured Debian VM with multiple ways to get root! SSH is available.
 * [Red Team Fundamentals](<https://tryhackme.com/room/redteamfundamentals>) - Learn about the basics of a red engagement, the main components and stakeholders involved, and how red teaming differs from other cyber security engagements.
 * [Red Team Recon](<https://tryhackme.com/room/redteamrecon>) - Learn how to use DNS, advanced searching, Recon-ng, and Maltego to collect information about your target.
+* [Nmap Tutorials](https://labex.io/tutorials/quick-start-with-nmap-free-tutorials-400132) - Learn and practice the basics of network scanning using Nmap.
 
 <!-- markdownlint-disable MD036 -->
 **Red Team Intro CTFs**<!-- markdownlint-enable MD036 -->


### PR DESCRIPTION
# Description

_Please include a summary of the resource you're suggesting below:_


I work at LabEx, a unique learning platform that has delivered thousands of free and paid hands-on labs over the past 7 years. 

* The Linux Commands Practice Course is a free course with 41 labs, covering the most commonly used Linux commands.
* The Nmap Tutorial is a series of free tutorials designed to help learners quickly get started with the basic uses of Nmap.

This repo is a great resource. Please let me know if any changes are needed.


# Checklist

_Please make sure you reviewed the checklist and comply with each requirement:_

* [x] My code follows the [contribution guidelines](../contributing.md) of this project
* [x] This resource is free and focuses on learn by doing style of learning
* [x] This pull request has a title in the format `Add Name of Resource`:
  * ✅ Add `ctf-practice`
  * ❌ Update readme.md

> ⚠️ PLEASE NOTE - Do not expect a prompt review for your PR unless you have truthfully went over contribution guidelines, filled the PR description correctly AND most importantly your changes are passing linters in [GitHub Actions pipeline](https://github.com/brootware/cyber-security-university/blob/main/.github/workflows/ci.yml).
