### PR TITLE
Add RansomLeak to free training platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Pull requests are welcome with the condition that the resource should be free! P
 
 ## Bonus CTF practice and Latest CVEs
 
+### Free Training Platforms
+
+* [RansomLeak Security Training](https://ransomleak.com/catalogue/security-awareness/) - Free browser-based interactive labs for Application Security, API Security, Cloud Security, Git Security, and AI Security. No installation or signup required.
+
+### CTF Challenges
+
 * [Bandit](<https://overthewire.org/wargames/bandit/>) - Aimed at absolute beginners and teaches the basics of remote server access.
 * [Natas](<https://overthewire.org/wargames/natas/>) - Teaches the basics of serverside web-security.
 * [Post Exploitation Basics](<https://tryhackme.com/room/postexploit>) - Learn the basics of post-exploitation and maintaining access with mimikatz, bloodhound, powerview and msfvenom.


### PR DESCRIPTION
Added [RansomLeak Security Training](https://ransomleak.com/catalogue/security-awareness/) to the **Bonus CTF practice** section as a free training platform option.

RansomLeak provides:
- **Free, browser-based interactive labs** (no installation required)
- Application Security training (OWASP Top 10)
- API Security training
- Cloud Security training (AWS, GCP, Azure misconfigurations)
- Git/Secrets Security training
- AI Security training (LLM attacks, prompt injection)

Perfect complement to the existing free paths in this repo. All catalogues are free to browse and practice.

Disclosure: I work on RansomLeak. Formatting matches the surrounding entries and all URLs return 200.

https://claude.ai/code/session_01HGMArmtREp8pabSevihxCz